### PR TITLE
Self-Sufficient Leuvensthein

### DIFF
--- a/demos/leuvenshtein/src/algorithm/myers.rs
+++ b/demos/leuvenshtein/src/algorithm/myers.rs
@@ -304,7 +304,8 @@ pub fn process_enc_query_enc_db(
                 let t = Instant::now();
 
                 // Check the first part of the character
-                let mut eq1 = sks.unchecked_sub_packed(
+                let mut eq1 = unchecked_sub_packed(
+                    &sks,
                     q1_vec.iter().collect(),
                     get_column(&db_enc_matrix, j - 1).iter().collect(),
                 );
@@ -319,10 +320,11 @@ pub fn process_enc_query_enc_db(
 
                 let eq1_ref: Vec<&Ciphertext> = eq1_lut.iter().collect(); // ?
 
-                eq1 = sks.unchecked_sub_packed(one_enc_vec_ref.clone(), eq1_ref);
+                eq1 = unchecked_sub_packed(&sks, one_enc_vec_ref.clone(), eq1_ref);
                 sks.unchecked_scalar_add_packed_assign(&mut eq1, 16);
 
-                let mut eq2 = sks.unchecked_sub_packed(
+                let mut eq2 = unchecked_sub_packed(
+                    &sks,
                     q2_vec.iter().collect(),
                     get_column(&db1_enc_matrix, j - 1).iter().collect(),
                 );
@@ -339,14 +341,15 @@ pub fn process_enc_query_enc_db(
                 let vin = extract_number_elements(&v_matrices, i, j - 1);
                 let hin = extract_number_elements(&h_matrices, i - 1, j);
 
-                let v1 = sks.unchecked_scalar_add_packed(vin.iter().collect(), 1);
-                let h1 = sks.unchecked_scalar_add_packed(hin.iter().collect(), 1);
+                let v1 = unchecked_scalar_add_packed(&sks, vin.iter().collect(), 1);
+                let h1 = unchecked_scalar_add_packed(&sks, hin.iter().collect(), 1);
 
                 let key1 = sks.unchecked_scalar_mul_packed(h1.iter().collect(), 3);
                 let key12 =
-                    sks.unchecked_add_packed(key1.iter().collect(), eq2_lut.iter().collect());
+                    unchecked_add_packed(&sks, key1.iter().collect(), eq2_lut.iter().collect());
 
-                let key = sks.unchecked_add_packed(key12.iter().collect(), v1.iter().collect());
+                let key =
+                    unchecked_add_packed(&sks, key12.iter().collect(), v1.iter().collect());
 
                 let mut ct_res = Vec::new();
 
@@ -362,8 +365,10 @@ pub fn process_enc_query_enc_db(
                     dbg_dec_vec.push(dec_tmp);
                 }
 
-                let v_res = sks.unchecked_sub_packed(ct_res.iter().collect(), hin.iter().collect());
-                let h_res = sks.unchecked_sub_packed(ct_res.iter().collect(), vin.iter().collect());
+                let v_res =
+                    unchecked_sub_packed(&sks, ct_res.iter().collect(), hin.iter().collect());
+                let h_res =
+                    unchecked_sub_packed(&sks, ct_res.iter().collect(), vin.iter().collect());
 
                 write_number_elements(&mut v_matrices, &v_res, i, j);
                 write_number_elements(&mut h_matrices, &h_res, i, j);

--- a/demos/leuvenshtein/src/main.rs
+++ b/demos/leuvenshtein/src/main.rs
@@ -56,7 +56,13 @@ fn main() -> Result<(), Box<dyn Error>> {
 }
 
 fn run_app<B: Backend>(terminal: &mut Terminal<B>, mut app: App) -> io::Result<()> {
-    let params: ClassicPBSParameters = tfhe::shortint::parameters::V0_11_PARAM_MESSAGE_LEUVENSHTEIN;
+    // security = 132 bits, p-fail = 2^-71.625
+    let mut v0_11_param_message_leuvenshtein =
+        tfhe::shortint::parameters::V0_11_PARAM_MESSAGE_2_CARRY_2_KS_PBS_TUNIFORM_2M64.clone();
+    v0_11_param_message_leuvenshtein.message_modulus = MessageModulus(16);
+    v0_11_param_message_leuvenshtein.carry_modulus = CarryModulus(1);
+
+    let params: ClassicPBSParameters = v0_11_param_message_leuvenshtein;
     let cks: ClientKey = ClientKey::new(params);
     let sks: ServerKey = ServerKey::new(&cks);
     let integer_server_key: IntegerServerKey =


### PR DESCRIPTION
This version aims making Leuvensthein self-sufficient, preventing patching TFHE-rs with changes specific to the demo.

It will require; however, the implementation of `apply_lookup_table_packed()` as another packed operation extension to shortint serverkey. Hence, we introduced the packed operations for FPGA extensions, I suggest incorporating this new function also in `/tfhe/src/shortint/fpga.rs`. The suggested change can be implemented with the patch;

```
diff --git a/tfhe/src/shortint/fpga.rs b/tfhe/src/shortint/fpga.rs
index a50b284e3..4f348bed4 100644
--- a/tfhe/src/shortint/fpga.rs
+++ b/tfhe/src/shortint/fpga.rs
@@ -4,6 +4,7 @@ use crate::shortint::ciphertext::Degree;
 use crate::shortint::engine::fill_accumulator_vector;
 use crate::shortint::server_key::LookupTableOwned;
 use crate::shortint::{Ciphertext, PBSOrder, ServerKey};
+use rayon::iter::*;
 
 impl ServerKey {
     ////////////////////////////////////////////////////////////////////////////
@@ -149,7 +150,7 @@ impl ServerKey {
         };
     }
 
-    pub(crate) fn keyswitch_programmable_bootstrap_assign_packed(
+    pub fn keyswitch_programmable_bootstrap_assign_packed(
         &self,
         cts: &mut Vec<Ciphertext>,
         luts: &[LookupVector],
@@ -163,4 +164,31 @@ impl ServerKey {
                 self.keyswitch_programmable_bootstrap_assign(ct, &l);
             });
     }
+
+    // Below are the alternatives to packed operations above, but aiming at
+    // parallel execution on CPU.
+
+    pub fn apply_lookup_table_packed(
+        &self,
+        cts: Vec<&Ciphertext>,
+        accs: &Vec<LookupTableOwned>,
+    ) -> Vec<Ciphertext> {
+        let mut ct_res: Vec<Ciphertext> = cts.iter().map(|&ct| ct.clone()).collect();
+
+        match self.pbs_order {
+            PBSOrder::KeyswitchBootstrap => {
+                ct_res
+                    .par_iter_mut()
+                    .zip(accs.par_iter())
+                    .for_each(|(ct, acc)| {
+                        self.keyswitch_programmable_bootstrap_assign(ct, acc);
+                    });
+            }
+            PBSOrder::BootstrapKeyswitch => {
+                panic!("Packed BootstrapKeyswitch is not supported")
+            }
+        };
+
+        ct_res
+    }
 }
```
