### PR TITLE
Fix/overflow

### DIFF
--- a/demos/fhe-aes/src/demo/app.rs
+++ b/demos/fhe-aes/src/demo/app.rs
@@ -24,7 +24,7 @@ use crate::demo::{
     ui::{
         drawer::Drawer,
         layout::LayoutManager,
-        widgets::{InputBox, OutputBox},
+        widgets::TextBox,
         worker::{WorkerManager, WorkerMsg},
     },
 };
@@ -39,9 +39,9 @@ pub struct App {
     pub(crate) last_size: (u16, u16),
     pub(crate) too_small: bool,
 
-    pub(crate) client_box: OutputBox,
-    pub(crate) server_box: OutputBox,
-    pub(crate) result_box: OutputBox,
+    pub(crate) client_box: TextBox,
+    pub(crate) server_box: TextBox,
+    pub(crate) result_box: TextBox,
 
     pub(crate) client_history: Vec<(String, Color)>,
     pub(crate) server_history: Vec<(String, Color)>,
@@ -69,9 +69,9 @@ impl App {
             last_size: original_size,
             too_small: false,
 
-            client_box: OutputBox::empty(),
-            server_box: OutputBox::empty(),
-            result_box: OutputBox::empty(),
+            client_box: TextBox::empty(),
+            server_box: TextBox::empty(),
+            result_box: TextBox::empty(),
 
             client_history: Vec::new(),
             server_history: Vec::new(),
@@ -205,7 +205,7 @@ impl App {
             OPERAND_TWO_FROM_LEFT
         };
 
-        let mut input_box = InputBox::new(
+        let mut input_box = TextBox::new(
             (
                 self.offsets.0 + from_left,
                 self.offsets.1 + OPERAND_AND_RESULT_BOXES_FROM_TOP,
@@ -304,7 +304,7 @@ impl App {
     }
 
     pub(crate) fn build_ui_boxes(&mut self) -> Result<()> {
-        self.client_box = OutputBox::new(
+        self.client_box = TextBox::new(
             (
                 CLIENT_BOX_FROM_LEFT + self.offsets.0,
                 CLIENT_BOX_FROM_TOP + self.offsets.1,
@@ -315,7 +315,7 @@ impl App {
         );
         self.client_box.draw(&mut self.stdout)?;
 
-        self.server_box = OutputBox::new(
+        self.server_box = TextBox::new(
             (
                 SERVER_BOX_FROM_LEFT + self.offsets.0,
                 SERVER_BOX_FROM_TOP + self.offsets.1,
@@ -326,7 +326,7 @@ impl App {
         );
         self.server_box.draw(&mut self.stdout)?;
 
-        self.result_box = OutputBox::new(
+        self.result_box = TextBox::new(
             (
                 RESULT_BOX_FROM_LEFT + self.offsets.0,
                 OPERAND_AND_RESULT_BOXES_FROM_TOP + self.offsets.1,

--- a/demos/fhe-aes/src/demo/constants.rs
+++ b/demos/fhe-aes/src/demo/constants.rs
@@ -4,7 +4,7 @@ use crossterm::style::Color;
 
 pub(crate) const TERMINAL_POLL_MS: u64 = 50;
 
-pub(crate) const OPERAND_RESULT_BOX_WIDTH: u16 = 31;
+pub(crate) const OPERAND_RESULT_BOX_WIDTH: u16 = 33;
 pub(crate) const OPERAND_RESULT_BOX_HEIGHT: u16 = 3;
 
 pub(crate) const CLIENT_SERVER_BOX_WIDTH: u16 = 58;

--- a/demos/fhe-aes/src/demo/ui/drawer.rs
+++ b/demos/fhe-aes/src/demo/ui/drawer.rs
@@ -6,7 +6,8 @@ use crossterm::style::{PrintStyledContent, Stylize, style};
 use crossterm::{QueueableCommand, execute};
 
 use crate::demo::constants::{
-    EQUALITY_COLOR, ERROR_COLOR, HINT_COLOR, INDENTED_STEPS_COLOR, INPUTS_COLOR, INST_COLOR, NEWS_COLOR, OPERAND_RESULT_BOX_HEIGHT, PLUS_COLOR, RESULT_COLOR, SPIN_FRAMES
+    EQUALITY_COLOR, ERROR_COLOR, HINT_COLOR, INDENTED_STEPS_COLOR, INPUTS_COLOR, INST_COLOR,
+    NEWS_COLOR, OPERAND_RESULT_BOX_HEIGHT, PLUS_COLOR, RESULT_COLOR, SPIN_FRAMES,
 };
 use crate::demo::ui::worker::LogKind;
 use crate::demo::{
@@ -116,8 +117,8 @@ impl Drawer for App {
             MoveTo(
                 INSTRUCTION_FROM_LEFT + self.offsets.0,
                 INSTRUCTION_FROM_TOP + self.offsets.1 + 1
-            ), 
-            PrintStyledContent(style("Overflow may occur if the sum exceeds 2¹²⁸ - 1.").with(INST_COLOR))
+            ),
+            PrintStyledContent(style("The demo supports up to 64-bit operands.").with(INST_COLOR))
         )
     }
 
@@ -158,14 +159,10 @@ impl Drawer for App {
                 self.server_box.get_origin().1,
             ),
         };
-        
+
         let y = base_y + 1 + line_idx;
         let mark = if ok { "✓" } else { "✗" };
-        let color = if ok {
-            NEWS_COLOR
-        } else {
-            ERROR_COLOR
-        };
+        let color = if ok { NEWS_COLOR } else { ERROR_COLOR };
 
         self.stdout
             .queue(MoveTo(right_x, y))?
@@ -207,12 +204,12 @@ impl Drawer for App {
             self.draw_equality()?;
             match res {
                 Ok(v) => {
-                    self
-                        .result_box
+                    self.result_box
                         .log(&mut self.stdout, &v.to_string(), RESULT_COLOR)?;
                 }
                 Err(_) => {
-                    self.result_box.log(&mut self.stdout, "Error", ERROR_COLOR)?;
+                    self.result_box
+                        .log(&mut self.stdout, "Error", ERROR_COLOR)?;
                 }
             }
         }
@@ -221,18 +218,24 @@ impl Drawer for App {
         for m in self.finished_marks.clone() {
             self.draw_mark_at(m.get_kind(), m.get_line_idx(), m.is_ok())?;
         }
-        
+
         if !self.too_small {
             for spinner in &self.spinners {
                 let (right_x, base_y) = match spinner.get_kind() {
-                    LogKind::Client => (self.client_box.right_edge_x(), self.client_box.get_origin().1),
-                    LogKind::Server => (self.server_box.right_edge_x(), self.server_box.get_origin().1),
+                    LogKind::Client => (
+                        self.client_box.right_edge_x(),
+                        self.client_box.get_origin().1,
+                    ),
+                    LogKind::Server => (
+                        self.server_box.right_edge_x(),
+                        self.server_box.get_origin().1,
+                    ),
                 };
                 let y = base_y + 1 + spinner.get_line_idx();
                 let ch = SPIN_FRAMES[spinner.get_frame() % SPIN_FRAMES.len()];
-                self.stdout
-                    .queue(MoveTo(right_x, y))?
-                    .queue(crossterm::style::PrintStyledContent(style(ch).with(spinner.get_color())))?;
+                self.stdout.queue(MoveTo(right_x, y))?.queue(
+                    crossterm::style::PrintStyledContent(style(ch).with(spinner.get_color())),
+                )?;
             }
             self.stdout.flush()?;
         }

--- a/demos/fhe-aes/src/demo/ui/widgets.rs
+++ b/demos/fhe-aes/src/demo/ui/widgets.rs
@@ -8,94 +8,16 @@ use crossterm::{
 
 use crate::demo::constants::{CLIENT_SERVER_BOX_PAD, INDENTED_STEPS_COLOR, INPUTS_COLOR};
 
-pub(crate) struct InputBox {
-    origin: (u16, u16),
-    width: u16,
-    height: u16,
-    label: &'static str,
-    buf: String,
-}
-
-pub(crate) struct OutputBox {
+pub(crate) struct TextBox {
     origin: (u16, u16),
     width: u16,
     height: u16,
     label: &'static str,
     current_line: u16,
+    input_buffer: Option<String>,
 }
 
-impl InputBox {
-    pub(crate) fn new(origin: (u16, u16), width: u16, height: u16, label: &'static str) -> Self {
-        Self {
-            origin,
-            width,
-            height,
-            label,
-            buf: String::new(),
-        }
-    }
-
-    pub(crate) fn set_origin(&mut self, origin: (u16, u16)) {
-        self.origin = origin;
-    }
-
-    pub(crate) fn get_mut_buf(&mut self) -> &mut String {
-        &mut self.buf
-    }
-
-    pub(crate) fn draw(&self, stdout: &mut Stdout) -> Result<()> {
-        let (x, y) = self.origin;
-
-        stdout
-            .queue(MoveTo(x, y))?
-            .queue(PrintStyledContent(style("┌").with(INDENTED_STEPS_COLOR)))?
-            .queue(PrintStyledContent(
-                style("─".repeat((self.width - 2) as usize)).with(INDENTED_STEPS_COLOR),
-            ))?
-            .queue(PrintStyledContent(style("┐").with(INDENTED_STEPS_COLOR)))?;
-
-        for row in 1..self.height - 1 {
-            stdout
-                .queue(MoveTo(x, y + row))?
-                .queue(PrintStyledContent(style("│").with(INDENTED_STEPS_COLOR)))?
-                .queue(MoveTo(x + self.width - 1, y + row))?
-                .queue(PrintStyledContent(style("│").with(INDENTED_STEPS_COLOR)))?;
-        }
-
-        stdout
-            .queue(MoveTo(x, y + self.height - 1))?
-            .queue(PrintStyledContent(style("└").with(INDENTED_STEPS_COLOR)))?
-            .queue(PrintStyledContent(
-                style("─".repeat((self.width - 2) as usize)).with(INDENTED_STEPS_COLOR),
-            ))?
-            .queue(PrintStyledContent(style("┘").with(INDENTED_STEPS_COLOR)))?;
-
-        stdout
-            .queue(MoveTo(x + 2, y))?
-            .queue(PrintStyledContent(
-                style(self.label).with(INDENTED_STEPS_COLOR),
-            ))?
-            .flush()?;
-
-        Ok(())
-    }
-
-    pub(crate) fn render(&self, out: &mut Stdout) -> Result<()> {
-        let (x, y) = self.origin;
-        let max = (self.width - 3) as usize;
-        let printable = format!(
-            "{:<width$}",
-            &self.buf[..self.buf.len().min(max)],
-            width = max
-        );
-
-        out.queue(MoveTo(x + 2, y + 1))?
-            .queue(PrintStyledContent(style(printable).with(INPUTS_COLOR)))?
-            .flush()
-    }
-}
-
-impl OutputBox {
+impl TextBox {
     pub(crate) fn empty() -> Self {
         Self {
             origin: (0, 0),
@@ -103,6 +25,7 @@ impl OutputBox {
             height: 0,
             label: "",
             current_line: 0,
+            input_buffer: None,
         }
     }
 
@@ -113,6 +36,7 @@ impl OutputBox {
             height,
             label,
             current_line: 0,
+            input_buffer: Some(String::from("")),
         }
     }
 
@@ -120,8 +44,24 @@ impl OutputBox {
         self.origin
     }
 
+    pub(crate) fn set_origin(&mut self, origin: (u16, u16)) {
+        self.origin = origin;
+    }
+
+    pub(crate) fn get_mut_buf(&mut self) -> &mut String {
+        self.input_buffer.as_mut().unwrap()
+    }
+
     pub(crate) fn get_width(&self) -> u16 {
         self.width
+    }
+
+    pub(crate) fn right_edge_x(&self) -> u16 {
+        self.origin.0 + self.width - CLIENT_SERVER_BOX_PAD
+    }
+
+    pub(crate) fn current_line_idx(&self) -> u16 {
+        self.current_line.saturating_sub(1)
     }
 
     pub(crate) fn draw(&self, stdout: &mut Stdout) -> Result<()> {
@@ -205,11 +145,14 @@ impl OutputBox {
         Ok(())
     }
 
-    pub(crate) fn right_edge_x(&self) -> u16 {
-        self.origin.0 + self.width - CLIENT_SERVER_BOX_PAD
-    }
+    pub(crate) fn render(&self, out: &mut Stdout) -> Result<()> {
+        let (x, y) = self.origin;
+        let max = (self.width - 3) as usize;
+        let buf = self.input_buffer.as_ref().unwrap();
+        let printable = format!("{:<width$}", &buf[..buf.len().min(max)], width = max);
 
-    pub(crate) fn current_line_idx(&self) -> u16 {
-        self.current_line.saturating_sub(1)
+        out.queue(MoveTo(x + 2, y + 1))?
+            .queue(PrintStyledContent(style(printable).with(INPUTS_COLOR)))?
+            .flush()
     }
 }


### PR DESCRIPTION
Closes: https://github.com/belfortlabs/hello-fpga/issues/18

The issue is a rendering problem. If there are too many digits, the result box flushes them and shows the remaining digits. For demo purposes I added a line that states that the operands are limited to 64-bit numbers instead of diminishing the look of the demo by applying larger boxes.