### PR TITLE
fix(scripts): cleanup_env.sh removes TFHE-rs from the wrong path

### DIFF
--- a/scripts/cleanup_env.sh
+++ b/scripts/cleanup_env.sh
@@ -5,7 +5,7 @@ export REPO_DIR="$(realpath "$(dirname "$(realpath "$0")")"/..)"
 ################################################################################
 # Cleanup TFHE-rs
 
-export TFHERS_DIR="$REPO_DIR/tfhe-rs"
+export TFHERS_DIR="$REPO_DIR/../tfhe-rs"
 
 cargo clean
 rm -rf $REPO_DIR/Cargo.lock


### PR DESCRIPTION
## Summary
`scripts/cleanup_env.sh` targets the wrong path for the TFHE-rs clone, so teardown is a no-op and leaves the multi-GB checkout on disk.

## Details
`scripts/prepare_env.sh` clones and patches TFHE-rs into `$REPO_DIR/../tfhe-rs` (a sibling of the repo), which is exactly what the workspace `Cargo.toml` references (`tfhe = { path = "../tfhe-rs/tfhe", ... }`). But `cleanup_env.sh` set `TFHERS_DIR="$REPO_DIR/tfhe-rs"` (inside the repo) — a path that never exists — so `rm -rf` did nothing and the entire TFHE-rs clone survived, the opposite of what the teardown script promises.

## Fix
Point cleanup at the same sibling directory `prepare_env.sh` creates.

## Verification
- Confirmed the mismatch across `prepare_env.sh` (clones to `../tfhe-rs`), the old `cleanup_env.sh` (`tfhe-rs`), and the root `Cargo.toml` (`../tfhe-rs/tfhe`).
- Filesystem simulation of the repo layout: old path resolved to a non-existent dir (clone survives); fixed path correctly removed the sibling `tfhe-rs`.
- `bash -n scripts/cleanup_env.sh` passes. Shell-only change; no Rust files touched.
