### PR TITLE
fix: correct QueryResult field access in leuvenshtein tests

### DIFF
--- a/demos/leuvenshtein/src/algorithm/myers.rs
+++ b/demos/leuvenshtein/src/algorithm/myers.rs
@@ -601,7 +601,10 @@ mod tests {
         let result = decrypt_and_compute_results(&mut enc_struct);
         app.post_process(result, &mut enc_struct, false);
         println!("STart Post Processing took: {:?}", start.elapsed());
-        assert_eq!(app.messages[0].1, "Bilbo Baggins");
+        assert_eq!(
+            app.messages[0].matched_name,
+            Some("Bilbo Baggins".to_string())
+        );
     }
 
     /// 3. FPGA – plain query, encrypted database, FHE evaluated on the FPGA.
@@ -631,6 +634,9 @@ mod tests {
         let result = decrypt_and_compute_results(&mut enc_struct);
         app.post_process(result, &mut enc_struct, true);
         println!("Post processing took: {:?}", start.elapsed());
-        assert_eq!(app.messages[0].1, "Bilbo Baggins");
+        assert_eq!(
+            app.messages[0].matched_name,
+            Some("Bilbo Baggins".to_string())
+        );
     }
 }


### PR DESCRIPTION
app.messages holds QueryResult structs, not tuples, so app.messages[0].1 failed to compile with E0609. Compare against the matched_name field instead.